### PR TITLE
Add some conversion helpers for sequences

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -6,8 +6,7 @@
             "revive",
             "goimports",
             "misspell",
-            "ineffassign",
-            "gofmt"
+            "ineffassign"
         ]
     },
     "run": {

--- a/sequences.go
+++ b/sequences.go
@@ -285,7 +285,7 @@ func Apply[U, V any](seq iter.Seq[U], f func(U) V) iter.Seq[V] {
 // Unpack returns two iterators that yield the keys and values of the sequence
 func Unpack[U, V any](seq iter.Seq2[U, V]) (iter.Seq[U], iter.Seq[V]) {
 	keys := func(yield func(U) bool) {
-		// nolint:gofmt
+		// nolint:revive
 		for k, _ := range seq {
 			if !yield(k) {
 				break

--- a/sequences.go
+++ b/sequences.go
@@ -321,6 +321,19 @@ func UnpackMap[U comparable, V any](in map[U]V) (iter.Seq[U], iter.Seq[V]) {
 	return keys, vals
 }
 
+// Index returns an iterator that yields the index and value of the yielded elements from the sequence
+func Index[T any](seq iter.Seq[T]) iter.Seq2[int, T] {
+	return func(yield func(int, T) bool) {
+		i := 0
+		for v := range seq {
+			if !yield(i, v) {
+				break
+			}
+			i++
+		}
+	}
+}
+
 // Tee returns n iterators that yield the elements of the sequence
 // If n == 1, the only element in the slice will be the original seq
 func Tee[T any](seq iter.Seq[T], n int) []iter.Seq[T] {

--- a/sequences.go
+++ b/sequences.go
@@ -302,6 +302,25 @@ func Unpack[U, V any](seq iter.Seq2[U, V]) (iter.Seq[U], iter.Seq[V]) {
 	return keys, vals
 }
 
+// UnpackMap returns two iterators that yield the keys and values of the map
+func UnpackMap[U comparable, V any](in map[U]V) (iter.Seq[U], iter.Seq[V]) {
+	keys := func(yield func(U) bool) {
+		for k := range in {
+			if !yield(k) {
+				break
+			}
+		}
+	}
+	vals := func(yield func(V) bool) {
+		for _, v := range in {
+			if !yield(v) {
+				break
+			}
+		}
+	}
+	return keys, vals
+}
+
 // Tee returns n iterators that yield the elements of the sequence
 // If n == 1, the only element in the slice will be the original seq
 func Tee[T any](seq iter.Seq[T], n int) []iter.Seq[T] {

--- a/sequences.go
+++ b/sequences.go
@@ -282,6 +282,26 @@ func Apply[U, V any](seq iter.Seq[U], f func(U) V) iter.Seq[V] {
 	}
 }
 
+// Unpack returns two iterators that yield the keys and values of the sequence
+func Unpack[U, V any](seq iter.Seq2[U, V]) (iter.Seq[U], iter.Seq[V]) {
+	keys := func(yield func(U) bool) {
+		// nolint:gofmt
+		for k, _ := range seq {
+			if !yield(k) {
+				break
+			}
+		}
+	}
+	vals := func(yield func(V) bool) {
+		for _, v := range seq {
+			if !yield(v) {
+				break
+			}
+		}
+	}
+	return keys, vals
+}
+
 // Tee returns n iterators that yield the elements of the sequence
 // If n == 1, the only element in the slice will be the original seq
 func Tee[T any](seq iter.Seq[T], n int) []iter.Seq[T] {

--- a/sequences_test.go
+++ b/sequences_test.go
@@ -411,6 +411,68 @@ func TestUnpack(t *testing.T) {
 	assert.Equal(t, []int{6, 5, 4, 3, 2, 1}, resV3)
 }
 
+func TestUnpackMap(t *testing.T) {
+	resK := []int{}
+	resV := []int{}
+	ik, iv := ro.UnpackMap(map[int]int{1: 6, 2: 5, 3: 4, 4: 3, 5: 2, 6: 1})
+	for v := range ik {
+		resK = append(resK, v)
+	}
+	for v := range iv {
+		resV = append(resV, v)
+	}
+	assert.ElementsMatch(t, []int{1, 2, 3, 4, 5, 6}, resK)
+	assert.ElementsMatch(t, []int{6, 5, 4, 3, 2, 1}, resV)
+
+	// if values are interrupted before keys, the keys should be unaffected
+
+	resK2 := []int{}
+	resV2 := []int{}
+	ik2, iv2 := ro.UnpackMap(map[int]int{1: 6, 2: 5, 3: 4, 4: 3, 5: 2, 6: 1})
+
+	for v := range iv2 {
+		resV2 = append(resV2, v)
+		break
+	}
+
+	for k := range ik2 {
+		resK2 = append(resK2, k)
+	}
+	assert.ElementsMatch(t, []int{1, 2, 3, 4, 5, 6}, resK2)
+	assert.Len(t, resV2, 1)
+
+	// if keys are interrupted before values, the values should be unaffected
+
+	resK3 := []int{}
+	resV3 := []int{}
+	ik3, iv3 := ro.UnpackMap(map[int]int{1: 6, 2: 5, 3: 4, 4: 3, 5: 2, 6: 1})
+
+	for k := range ik3 {
+		resK3 = append(resK3, k)
+		break
+	}
+
+	for v := range iv3 {
+		resV3 = append(resV3, v)
+	}
+
+	assert.Len(t, resK3, 1)
+	assert.ElementsMatch(t, []int{6, 5, 4, 3, 2, 1}, resV3)
+
+	resK4 := []int{}
+	resV4 := []int{}
+
+	ik4, iv4 := ro.UnpackMap(map[int]int{})
+	for v := range ik4 {
+		resK4 = append(resK4, v)
+	}
+	for v := range iv4 {
+		resV4 = append(resV4, v)
+	}
+	assert.Equal(t, []int{}, resK4)
+	assert.Equal(t, []int{}, resV4)
+}
+
 func TestTee(t *testing.T) {
 	iters := ro.Tee(ro.FromSlice([]int{1, 2, 3, 4, 5}), 3)
 

--- a/sequences_test.go
+++ b/sequences_test.go
@@ -473,6 +473,26 @@ func TestUnpackMap(t *testing.T) {
 	assert.Equal(t, []int{}, resV4)
 }
 
+func TestIndex(t *testing.T) {
+	res := []int{}
+	ind := []int{}
+	for i, v := range ro.Index(ro.FromSlice([]int{1, 2, 3, 4, 5})) {
+		ind = append(ind, i)
+		res = append(res, v)
+	}
+	assert.Equal(t, []int{1, 2, 3, 4, 5}, res)
+	assert.Equal(t, []int{0, 1, 2, 3, 4}, ind)
+
+	res2 := []int{}
+	ind2 := []int{}
+	for i, v := range ro.Index(ro.FromSlice([]int{})) {
+		res2 = append(res2, v)
+		ind2 = append(ind2, i)
+	}
+	assert.Equal(t, []int{}, res2)
+	assert.Equal(t, []int{}, ind2)
+}
+
 func TestTee(t *testing.T) {
 	iters := ro.Tee(ro.FromSlice([]int{1, 2, 3, 4, 5}), 3)
 

--- a/types.go
+++ b/types.go
@@ -62,3 +62,14 @@ func FromString(s string) iter.Seq[rune] {
 		}
 	}
 }
+
+// Extend pads an iterator with an empty struct to conform to an iter.Seq2 type
+func Extend[T any](seq iter.Seq[T]) iter.Seq2[struct{}, T] {
+	return func(yield func(struct{}, T) bool) {
+		for v := range seq {
+			if !yield(struct{}{}, v) {
+				break
+			}
+		}
+	}
+}

--- a/types_test.go
+++ b/types_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/alexandreLamarre/ro"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -60,4 +61,27 @@ func TestFromString(t *testing.T) {
 		res2 = append(res2, v)
 	}
 	assert.Equal(t, []rune{}, res2)
+}
+
+func iter2ToTuple[U, V any](seq iter.Seq2[U, V]) []lo.Tuple2[U, V] {
+	res := []lo.Tuple2[U, V]{}
+	for k, v := range seq {
+		res = append(res, lo.Tuple2[U, V]{A: k, B: v})
+	}
+	return res
+}
+
+func TestExtend(t *testing.T) {
+	i := ro.FromSlice([]int{1, 2, 3})
+	kv := ro.Extend(i)
+
+	assert.Equal(t, []lo.Tuple2[struct{}, int]{
+		{A: struct{}{}, B: 1},
+		{A: struct{}{}, B: 2},
+		{A: struct{}{}, B: 3},
+	}, iter2ToTuple(kv))
+
+	i2 := ro.FromSlice([]string{})
+	kv2 := ro.Extend(i2)
+	assert.Equal(t, []lo.Tuple2[struct{}, string]{}, iter2ToTuple(kv2))
 }


### PR DESCRIPTION
- function `Extend` to pad an `iter.Seq[T]` to an `iter.Seq2[struct{}, T]`
- function `Unpack` to convert an `iter.Seq2[U,V]` to its corresponding `iter.Seq[U]` and `iter.Seq[V]`
- function `UnpackMap` to convert a `map[K]V` to its corresponding `iter.Seq[K]` and `iter.Seq[V]`
- function `Index` which adds indices to an `iter.Seq[T]` in the form of `iter.Seq2[int, T]`