### PR TITLE
range over iterator

### DIFF
--- a/sequences.go
+++ b/sequences.go
@@ -334,6 +334,31 @@ func Index[T any](seq iter.Seq[T]) iter.Seq2[int, T] {
 	}
 }
 
+// RangeOver returns an iterator that yields the elements of the sequence from start to stop incrementing by step
+func RangeOver[T any](seq iter.Seq[T], start, step, stop int) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		i := 0
+		k := 0
+		for v := range seq {
+			if i >= stop {
+				break
+			}
+			if i < start {
+				i++
+				continue
+			}
+			if k%step == 0 {
+				if !yield(v) {
+					break
+				}
+			}
+			i++
+			k++
+		}
+	}
+
+}
+
 // Tee returns n iterators that yield the elements of the sequence
 // If n == 1, the only element in the slice will be the original seq
 func Tee[T any](seq iter.Seq[T], n int) []iter.Seq[T] {

--- a/sequences_test.go
+++ b/sequences_test.go
@@ -618,6 +618,28 @@ func TestUnpackMap(t *testing.T) {
 	assert.Equal(t, []int{}, resV4)
 }
 
+func TestRangeOver(t *testing.T) {
+	res := []int{}
+	it := ro.FromSlice([]int{1, 2, 3, 4, 5, 6, 7, 8})
+	for v := range ro.RangeOver(it, 1, 2, 10) {
+		res = append(res, v)
+	}
+	assert.Equal(t, []int{2, 4, 6, 8}, res)
+
+	res2 := []int{}
+	for v := range ro.RangeOver(ro.FromSlice([]int{}), 0, 2, 5) {
+		res2 = append(res2, v)
+	}
+	assert.Equal(t, []int{}, res2)
+
+	res3 := []int{}
+	for v := range ro.RangeOver(ro.FromSlice([]int{1, 2, 3, 4, 5, 6, 7, 8}), 0, 2, 10) {
+		res3 = append(res3, v)
+		break
+	}
+	assert.Equal(t, []int{1}, res3)
+}
+
 func TestIndex(t *testing.T) {
 	res := []int{}
 	ind := []int{}


### PR DESCRIPTION
 traditional for loop `for i:=0; i<n;i++` but for iterators in the form `ro.RangeOver(iter, start,step,end)`