### PR TITLE
Bump to go 1.23

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,9 +13,6 @@ permissions:
   # Optional: allow read access to pull request. Use with `only-new-issues` option.
   # pull-requests: read
 
-env:
-  GOEXPERIMENT: rangefunc
-
 jobs:
   golangci:
     name: lint
@@ -24,11 +21,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: '1.23'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: v1.56
+          version: v1.60.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22
+        go-version: '1.23'
     # remove tests in order to clean dependencies
     - name: Remove xxx_test.go files
       run: rm -rf *_test.go 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,9 +22,6 @@ on:
 permissions:
   contents: read
 
-env:
-  GOEXPERIMENT: rangefunc
-
 jobs:
   build:
     name: test
@@ -35,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: '1.23'
       - name: Run tests
         run: go test -v -timeout 30s -coverprofile=cover.out -covermode=atomic -race ./...
       - name: Upload coverage reports to Codecov

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ro
 
-![Go Version](https://img.shields.io/badge/Go-%3E%3D%201.22-%23007d9c)
+![Go Version](https://img.shields.io/badge/Go-%3E%3D%201.23-%23007d9c)
 ![Release](https://img.shields.io/github/v/release/alexandreLamarre/ro)
 [![GoDoc](https://godoc.org/github.com/alexandreLamarre/ro?status.svg)](https://pkg.go.dev/github.com/alexandreLamarre/ro)
 [![Lint](https://github.com/alexandreLamarre/ro/actions/workflows/lint.yaml/badge.svg)](https://github.com/alexandreLamarre/ro/actions/workflows/lint.yaml)
@@ -23,11 +23,7 @@ go get github.com/alexandreLamarre/ro@v0.1.0
 
 ## ✔️ Requirements
 
-This library requires you to enable the go experimental feature [rangefunc](https://go.dev/wiki/RangefuncExperiment) :
-
-```sh
-export GOEXPERIMENT=rangefunc
-```
+This library requires you to use go 1.23.X or greater.
 
 ## 💡 Usage
 

--- a/combinatorics.go
+++ b/combinatorics.go
@@ -1,5 +1,3 @@
-//go:build goexperiment.rangefunc
-
 package ro
 
 import (

--- a/combinatorics_test.go
+++ b/combinatorics_test.go
@@ -1,5 +1,3 @@
-//go:build goexperiment.rangefunc
-
 package ro_test
 
 import (

--- a/finite.go
+++ b/finite.go
@@ -1,5 +1,3 @@
-//go:build goexperiment.rangefunc
-
 package ro
 
 import "iter"

--- a/finite_test.go
+++ b/finite_test.go
@@ -1,5 +1,3 @@
-//go:build goexperiment.rangefunc
-
 package ro_test
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/alexandreLamarre/ro
 
-go 1.22.2
+go 1.23
 
 require (
-	github.com/samber/lo v1.42.0
+	github.com/samber/lo v1.46.0
 	// test dependencies are excluded from CI
 
 	github.com/stretchr/testify v1.9.0
@@ -12,7 +12,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,14 +2,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/samber/lo v1.39.0 h1:4gTz1wUhNYLhFSKl6O+8peW0v2F4BCY034GRpU9WnuA=
-github.com/samber/lo v1.39.0/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
-github.com/samber/lo v1.42.0 h1:cuVp/4oZcTxK0w8vyj/MSEws9yTUjuTgZi7noEXMlZs=
-github.com/samber/lo v1.42.0/go.mod h1:w7R6fO7h2lrnx/s0bWcZ55vXJI89p5UPM6+kyDL373E=
+github.com/samber/lo v1.46.0 h1:w8G+oaCPgz1PoCJztqymCFaKwXt+5cCXn51uPxExFfQ=
+github.com/samber/lo v1.46.0/go.mod h1:RmDH9Ct32Qy3gduHQuKJ3gW1fMHAnE/fAzQuf6He5cU=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 h1:3MTrJm4PyNL9NBqvYDSj3DHl46qQakyfqfWo4jgfaEM=
-golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/text v0.16.0 h1:a94ExnEXNtEwYLGJSIUxnWoxoRz/ZcCsV63ROupILh4=
 golang.org/x/text v0.16.0/go.mod h1:GhwF1Be+LQoKShO3cGOHzqOgRrGaYc9AvblQOmPVHnI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/infinite.go
+++ b/infinite.go
@@ -1,5 +1,3 @@
-//go:build goexperiment.rangefunc
-
 package ro
 
 import "iter"

--- a/infinite_test.go
+++ b/infinite_test.go
@@ -1,5 +1,3 @@
-//go:build goexperiment.rangefunc
-
 package ro_test
 
 import (

--- a/sequences.go
+++ b/sequences.go
@@ -56,37 +56,6 @@ func AccumulateFunc[T any](seq iter.Seq[T], f func(T, T) T) iter.Seq[T] {
 	}
 }
 
-// BatchSlice returns an iterator that yields batches of size elements from the slice
-func BatchSlice[T any](arr []T, size int) iter.Seq[[]T] {
-	return func(yield func([]T) bool) {
-		for i := 0; i < len(arr); i += size {
-			end := min(i+size, len(arr))
-			if !yield(arr[i:end]) {
-				break
-			}
-		}
-	}
-}
-
-// Batch returns an iterator that yields batches of size elements yielded by seq
-func Batch[T any](seq iter.Seq[T], size int) iter.Seq[[]T] {
-	return func(yield func([]T) bool) {
-		batch := []T{}
-		for v := range seq {
-			batch = append(batch, v)
-			if len(batch) == size {
-				if !yield(batch) {
-					return
-				}
-				batch = []T{}
-			}
-		}
-		if len(batch) > 0 {
-			yield(batch)
-		}
-	}
-}
-
 // ChainSlice returns an iterator that yields the elements of the slice in order
 func ChainSlice[T any](arr ...[]T) iter.Seq[T] {
 	return func(yield func(T) bool) {

--- a/sequences.go
+++ b/sequences.go
@@ -1,5 +1,3 @@
-//go:build goexperiment.rangefunc
-
 package ro
 
 import (

--- a/sequences_test.go
+++ b/sequences_test.go
@@ -97,56 +97,6 @@ func TestAccumulateFunc(t *testing.T) {
 	assert.Equal(t, [][]string{{"a", "b"}}, res3)
 }
 
-func TestBatchSlice(t *testing.T) {
-	seq := []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
-	res := [][]int{}
-	for v := range ro.BatchSlice(seq, 3) {
-		res = append(res, v)
-	}
-	assert.Equal(t, [][]int{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, res)
-
-	empty := []int{}
-	res2 := [][]int{}
-	for v := range ro.BatchSlice(empty, 3) {
-		res2 = append(res2, v)
-	}
-	assert.Equal(t, [][]int{}, res2)
-
-	res3 := [][]int{}
-	for v := range ro.BatchSlice(seq, 3) {
-		res3 = append(res3, v)
-		break
-	}
-	assert.Equal(t, [][]int{{1, 2, 3}}, res3)
-}
-
-func TestBatch(t *testing.T) {
-	res := [][]int{}
-	for v := range ro.Batch(ro.FromSlice([]int{1, 2, 3, 4, 5, 6, 7, 8, 9}), 3) {
-		res = append(res, v)
-	}
-	assert.Equal(t, [][]int{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, res)
-
-	res2 := [][]int{}
-	for v := range ro.Batch(ro.FromSlice([]int{}), 3) {
-		res2 = append(res2, v)
-	}
-	assert.Equal(t, [][]int{}, res2)
-
-	res3 := [][]int{}
-	for v := range ro.Batch(ro.FromSlice([]int{1, 2, 3, 4, 5, 6, 7, 8, 9}), 3) {
-		res3 = append(res3, v)
-		break
-	}
-	assert.Equal(t, [][]int{{1, 2, 3}}, res3)
-
-	res4 := [][]int{}
-	for v := range ro.Batch(ro.FromSlice([]int{1, 2, 3, 4, 5, 6, 7, 8}), 3) {
-		res4 = append(res4, v)
-	}
-	assert.Equal(t, [][]int{{1, 2, 3}, {4, 5, 6}, {7, 8}}, res4)
-}
-
 func TestChainSlice(t *testing.T) {
 	res := []int{}
 	for v := range ro.ChainSlice([]int{1, 2, 3}, []int{4, 5, 6}, []int{7, 8, 9}) {

--- a/sequences_test.go
+++ b/sequences_test.go
@@ -1,5 +1,3 @@
-//go:build goexperiment.rangefunc
-
 package ro_test
 
 import (

--- a/types.go
+++ b/types.go
@@ -1,5 +1,3 @@
-//go:build goexperiment.rangefunc
-
 package ro
 
 import "iter"

--- a/types_test.go
+++ b/types_test.go
@@ -1,5 +1,3 @@
-//go:build goexperiment.rangefunc
-
 package ro_test
 
 import (


### PR DESCRIPTION
Bump to go 1.23 where rangfunc is stabilized as part of the core language.

Other changes :

`slices.Chunk` from the standarad library replaces the functionality of `Batch` / `BatchSlice`, so they have been removed